### PR TITLE
Feat: Inviting users should store original user id not email.

### DIFF
--- a/prisma/services/workspace.js
+++ b/prisma/services/workspace.js
@@ -232,7 +232,7 @@ export const getWorkspacePaths = async () => {
 
 export const inviteUsers = async (id, email, members, slug) => {
   const workspace = await getOwnWorkspace(id, email, slug);
-  const inviter = email;
+  const inviter = id;
 
   if (workspace) {
     const membersList = members.map(({ email, role }) => ({


### PR DESCRIPTION
For security the id of the user inviting a new user should be stored forever, however in the previous code it would only store the email. Since the email can be changed at any time by any user you could end up with a situation where you don't know which of your users invited the new user after an email change.  For slightly better application hardening lets store the id instead as it follows the user for their whole lifetime using the app.