### PR TITLE
docs(d): add CLAUDE.md, AGENTS.md, ARCHITECTURE.md, CONVENTIONS.md, R…

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,31 @@
+# Nextacular — Cursor rules
+
+Multi-tenant SaaS boilerplate for Next.js (Pages Router, TypeScript strict, Prisma 6, NextAuth 4, Stripe, Tailwind 3 + Headless UI 1.7). Optimize every change for downstream forkers — keep the surface area small and conventions consistent.
+
+Full guidance: see CLAUDE.md and docs/CONVENTIONS.md.
+
+## Hard rules
+
+1. Workspace-scoped API routes MUST call `requireWorkspaceOwner`, `requireWorkspaceMember`, or `requireMemberInOwnedWorkspace` from `src/lib/server/authorization.ts` before touching the database. Session presence alone is insufficient (this gap was a CVE in v1.4.2).
+2. Files under `src/lib/server/` are server-only. Never import them from a client component or page that renders on the client.
+3. `@prisma/client` is imported only from `prisma/services/*` and `prisma/index.ts`. Routes call services; services call Prisma.
+4. API error responses use the shape `{ errors: { <field>: { msg: '<message>' } } }`. Client toasts depend on this.
+5. Validate request bodies with `parseBody(schema, req.body, res)` from `src/lib/server/validate.ts`. Schemas live in `src/config/api-validation/` and use Zod.
+6. TypeScript: `strict: true` and `noUncheckedIndexedAccess: true`. No `any`, no `@ts-ignore` without a one-line reason.
+7. Use the `@/...` path aliases from `tsconfig.json`. No deep relative imports.
+8. New environment variables: update `.env.sample` AND `docs/ENV.md`. Never bundle secrets behind `NEXT_PUBLIC_*`.
+
+## Patterns to follow
+
+- API routes: see `src/pages/api/workspace/[workspaceSlug]/name.ts` for the canonical `(validateSession + parseBody + requireWorkspaceOwner)` shape.
+- Workspace-scoped pages: see `src/pages/account/[workspaceSlug]/settings/general.tsx` for the `getServerSideProps` pattern (session + `getWorkspace` + `isWorkspaceOwner` + workspace context).
+- Data hooks: see `src/hooks/data/useMembers.ts` for the `useSWR` + typed-result shape.
+- Compound components: see `src/components/Card/index.tsx` for the `FC` + named sub-components + `displayName` pattern.
+
+## Don't
+
+- Introduce a state-management library (the app uses React state + SWR + one Context).
+- Replace the UI library mid-stream (Headless UI 1 + Tailwind is the contract until the planned shadcn migration in v2.0).
+- Add raw SQL, Drizzle, or Kysely. Prisma services only.
+- Use `defaultProps` on function components. Use destructured defaults.
+- Disable `strict` or `noUncheckedIndexedAccess`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md
+
+Operating guide for AI coding agents (OpenAI Codex CLI, Aider, Continue, generic LLM agents). The canonical content lives in [`CLAUDE.md`](CLAUDE.md) — this file exists so agents that look for `AGENTS.md` first find their way there.
+
+**Read [`CLAUDE.md`](CLAUDE.md).** It covers:
+
+- What this project is and who its users are
+- The current tech stack with versions
+- The full file map and where each kind of code belongs
+- The conventions we enforce in code review
+- The architecture in one paragraph (and the link to the deeper write-up)
+- What to do when you're adding common things (API routes, pages, hooks, services)
+- What not to do
+- The first six files you should read to get oriented
+
+Cursor users: the same content is condensed for the Cursor model in [`.cursorrules`](.cursorrules).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New npm scripts: `db:up`, `db:down`, `db:reset`, `db:logs`, `db:studio`, `seed`. Local dev now boots with `npm install && npm run db:up && npx prisma migrate deploy && npm run seed && npm run dev`.
 - Seed script (`prisma/seed.ts`, replacing `prisma/seed.js`) creates a demo workspace with an admin owner and two teammate users (one accepted, one pending invitation) so the dashboard is non-empty on first run.
 - `docs/ENV.md` — full reference for every environment variable: required vs. optional, where to get each value, examples for hosted Postgres and Stripe webhooks.
+- `docs/ARCHITECTURE.md` — multi-tenancy (subdomain + custom domain routing), authentication, workspaces / members / teams, billing and Stripe webhook flow, and the data model.
+- `docs/CONVENTIONS.md` — the full coding conventions enforced in code review: TypeScript, file organization, API route shape, error envelope, validation, authorization, page structure, naming, commit style.
+- `docs/RECIPES.md` — copy-paste guides for "add an API route", "add a workspace-scoped page", "add a data hook", "add a Prisma model", "add a billing-gated feature", "add a landing section", "add an environment variable", "send an email".
+- `CLAUDE.md` at repo root — operating guide for Claude Code, Cursor, GitHub Copilot, and any AI assistant. Mirrored by a short `AGENTS.md` pointer and a condensed `.cursorrules` for Cursor IDE.
 - Rewritten `.env.sample` with defaults that match `docker-compose.yml` and inline guidance grouped by feature area.
 - `tsx` devDependency so Prisma can run TypeScript seed and script files directly.
+- Server-side validation via Zod (`src/lib/server/validate.ts` → `parseBody`); schemas live in `src/config/api-validation/`.
+- `src/lib/client/clipboard.ts` (native Clipboard API wrapper) and `src/lib/server/raw-body.ts` (Stripe webhook raw body reader).
 
 ### Changed
 
 - TypeScript-first codebase: `src/`, `prisma/services/`, `src/lib/`, the API routes, components, layouts, pages, and middleware are all `.ts` / `.tsx`. `strict: true` + `noUncheckedIndexedAccess: true`. CI now runs `tsc --noEmit` on every PR.
 - Tooling foundation: Node 22 pinned via `.nvmrc` and `engines`, Prettier + EditorConfig, tightened ESLint (`no-console` as warn, `prefer-const`, `eqeqeq`, `no-var`), GitHub Actions CI (lint + format + typecheck + build with a Postgres service container), CodeQL workflow on a weekly schedule, `SECURITY.md`, PR template.
-- `CONTRIBUTING.md` rewritten with the docker-compose workflow and a scripts reference table.
+- `CONTRIBUTING.md` rewritten with the docker-compose workflow, a scripts reference table, and pointers to `CLAUDE.md` + the new `docs/` guides.
+- Prisma 4 → 6 (no source changes required; schema avoided every Prisma 5/6 breaking-change vector).
+- Dependencies refreshed within compatible majors: next 13.5.1 → 13.5.11, next-auth 4.24.5 → 4.24.14, react 18.2 → 18.3.1, tailwindcss 3.3 → 3.4, eslint 8.38 → 8.57, and others.
+- `nodemailer` 6 → 7 (required by `next-auth` 4.24's peer; existing `sendMail` API unchanged).
+
+### Removed
+
+- `react-topbar-progress-indicator` → replaced with `nprogress` wired to Router events.
+- `react-ga` (end-of-life with Universal Analytics) → replaced with `gtag.js` injected via `next/script`.
+- `react-copy-to-clipboard` → replaced with the native Clipboard API.
+- `micro` → replaced with a 7-line `readRawBody` helper for the Stripe webhook handler.
+- `express-validator` → replaced with Zod schemas and the `parseBody` helper.
 
 ## [1.4.2] - 2026-05-30
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,162 @@
+# CLAUDE.md
+
+Operating guide for Claude Code, Cursor, GitHub Copilot, and any other AI assistant working on this repository. Humans should read it too — it's the fastest way to get oriented.
+
+This file is mirrored by `AGENTS.md` (vendor-neutral pointer) and a condensed `.cursorrules`. Keep this file as the canonical source of truth and treat the others as derived.
+
+## What this project is
+
+Nextacular is an **open-source multi-tenant SaaS boilerplate** for Next.js. Users (typically indie hackers and small teams) fork it to skip the standard "auth + workspaces + teams + billing + custom domains" plumbing and jump straight to product code.
+
+Optimize every change for **downstream forkers**, not just for this repo. Don't break the conventions in [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md); don't add features that only make sense to one consumer.
+
+## Tech stack
+
+| Layer        | Choice                                                | Version  |
+| ------------ | ----------------------------------------------------- | -------- |
+| Framework    | Next.js (Pages Router)                                | 13.5.x   |
+| Language     | TypeScript with `strict` + `noUncheckedIndexedAccess` | 5.6      |
+| UI           | React 18 + Tailwind CSS 3 + Headless UI 1.7           | —        |
+| Data         | Prisma + PostgreSQL                                   | Prisma 6 |
+| Auth         | NextAuth 4 (Email magic link + Prisma adapter)        | 4.24     |
+| Validation   | Zod (server) + `validator/` (client)                  | Zod 4    |
+| Payments     | Stripe SDK + Stripe Checkout                          | 10.x     |
+| Custom DNS   | Vercel Domains API                                    | —        |
+| Email        | nodemailer; Mailpit for local capture                 | 7.x      |
+| i18n         | i18next + react-i18next                               | 23.x     |
+| Tests        | _not yet wired up_                                    | —        |
+| Local infra  | Docker Compose (Postgres + Mailpit + Adminer)         | —        |
+| Node runtime | 22 (Active LTS); pinned in `.nvmrc` and `engines`     | —        |
+
+Major upgrades currently in scope for the next release (see `CHANGELOG.md` → Unreleased and the v2.0 plan in PRs/issues): Next 13 → 15, Pages Router → App Router, Headless UI 1 → 2, shadcn/ui adoption, NextAuth 4 → Auth.js v5. None of these have landed yet. Write code against the current stack.
+
+## File map
+
+```
+prisma/
+  schema.prisma          ← source of truth for the data model
+  seed.ts                ← demo workspace + admin + teammates (run via `npm run seed`)
+  services/              ← *the only place* `@prisma/client` is imported from
+src/
+  config/
+    api-validation/      ← one Zod schema per API endpoint, re-exported from index.ts
+    email-templates/     ← html() + text() generators per outgoing email type
+    menu/                ← sidebar menu trees (workspace-scoped vs static)
+    swr/                 ← SWR global config (fetcher + onError)
+    subscription-rules/  ← per-plan quotas (FREE / STANDARD / PREMIUM)
+  components/            ← presentational React: Button, Card, Modal, Sidebar, etc.
+  hooks/
+    data/                ← thin useSWR wrappers, one per data resource
+  layouts/               ← AccountLayout, AuthLayout, LandingLayout, PublicLayout
+  lib/
+    client/              ← code safe to import from client components
+    common/              ← code safe to import from either side
+    server/              ← *server-only*; never import from client components
+      authorization.ts   ← `requireWorkspaceOwner` / `requireWorkspaceMember`
+      auth.ts            ← NextAuth `authOptions`
+      raw-body.ts        ← Stripe webhook raw body reader
+      stripe.ts          ← server Stripe client
+      mail.ts            ← nodemailer transport + sendMail
+      validate.ts        ← `parseBody(schema, body, res)`
+  messages/              ← i18n catalogs (`en.json` only today)
+  middleware.ts          ← subdomain → /_sites/[site] rewrite
+  pages/
+    api/                 ← all API routes (Pages Router)
+    _sites/[site]/       ← rendered when the request comes in on a tenant subdomain
+    account/             ← authenticated app pages (uses AccountLayout)
+    auth/                ← login/magic-link UI
+    teams/invite.tsx     ← join-by-link landing page
+    index.tsx            ← marketing landing page
+    _app.tsx             ← global providers (Session, SWR, Theme, Workspace, i18n)
+  providers/             ← React context providers (currently: `workspace`)
+  sections/              ← landing-page composition: Hero, Features, Pricing, etc.
+  styles/globals.css     ← Tailwind directives + NProgress overrides
+  types/                 ← global.d.ts (window.gtag), next-auth.d.ts (Session shape)
+docs/
+  ARCHITECTURE.md        ← multi-tenancy, auth, billing, data model
+  CONVENTIONS.md         ← code conventions enforced across the repo
+  RECIPES.md             ← copy-paste guides for common tasks
+  ENV.md                 ← every environment variable, required vs optional
+```
+
+## Architecture in one paragraph
+
+Each customer of a Nextacular-based app is a **Workspace**. A user creates workspaces and is automatically their `OWNER`; other users join via an invite link or are added via email. Workspaces can attach custom domains (via the Vercel API), so the same app serves the marketing page at `app.com`, the dashboard at `app.com/account/<slug>`, the tenant's subdomain at `<slug>.app.com`, and an optional custom domain `customer.com`. The middleware rewrites tenant requests into `/_sites/[site]` and the marketing/dashboard requests are served normally. Authentication is NextAuth magic-link email; sessions carry `userId` and an optional `subscription` field hydrated from the Stripe-backed `CustomerPayment` table.
+
+Read [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full version.
+
+## Conventions you must follow
+
+These are enforced by either CI (lint, typecheck, format) or convention (we won't merge a PR that violates them).
+
+1. **Authorization on workspace-scoped routes.** Any API route that reads or writes data belonging to a workspace MUST call `requireWorkspaceOwner`, `requireWorkspaceMember`, or `requireMemberInOwnedWorkspace` from `src/lib/server/authorization.ts` before touching the database. `validateSession` alone is insufficient — that authorization gap was the v1.4.2 CVE.
+2. **Server-only code stays server-only.** Anything under `src/lib/server/` MUST NOT be imported from a file that runs on the client. The Stripe secret, email transport, and Prisma client live here. Importing `@prisma/client` from outside `prisma/services/` is also disallowed.
+3. **No raw `@prisma/client` in pages or API routes.** Routes call services; services call Prisma. This is the only way we keep query intent reviewable.
+4. **Error response shape.** Every API error response uses `{ errors: { <field>: { msg: '<message>' } } }`. The existing `toast.error(response.errors[k].msg)` pattern on the client depends on this.
+5. **Validate at the boundary with Zod.** Every API route that consumes a body parses it with `parseBody(schema, req.body, res)` from `src/lib/server/validate.ts`. Schemas live in `src/config/api-validation/`.
+6. **TypeScript strictness.** `strict: true` and `noUncheckedIndexedAccess: true`. No `any`, no `@ts-ignore` without a comment that names the underlying issue.
+7. **Imports.** Use the `@/...` path aliases declared in `tsconfig.json`. Never use deep relative imports (`../../../`).
+8. **No defaultProps.** Use destructured default parameters (React 18 deprecates `defaultProps` on function components).
+9. **Translation strings** go through `useTranslation()`. New keys go in `src/messages/en.json`.
+
+Full list with rationale and examples: [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md).
+
+## When you add things
+
+| Adding…                    | Read this                                                                                        |
+| -------------------------- | ------------------------------------------------------------------------------------------------ |
+| A new API route            | [`docs/RECIPES.md` → "Add an API route"](docs/RECIPES.md#add-an-api-route)                       |
+| A workspace-scoped page    | [`docs/RECIPES.md` → "Add a workspace-scoped page"](docs/RECIPES.md#add-a-workspace-scoped-page) |
+| A data hook                | [`docs/RECIPES.md` → "Add a data hook"](docs/RECIPES.md#add-a-data-hook)                         |
+| A Prisma model + service   | [`docs/RECIPES.md` → "Add a Prisma model"](docs/RECIPES.md#add-a-prisma-model)                   |
+| A billing-gated feature    | [`docs/RECIPES.md` → "Add a billing-gated feature"](docs/RECIPES.md#add-a-billing-gated-feature) |
+| A landing-page section     | [`docs/RECIPES.md` → "Add a landing section"](docs/RECIPES.md#add-a-landing-section)             |
+| A new environment variable | [`docs/ENV.md`](docs/ENV.md) AND update `.env.sample`                                            |
+| A new translation string   | `src/messages/en.json` (single source today; future locales go beside it)                        |
+
+If the task isn't covered, find a similar existing file and follow its shape. Symmetry across the codebase matters more than micro-optimizations.
+
+## Commands you'll use most
+
+```sh
+# Local dev
+npm run db:up         # Postgres + Mailpit + Adminer in Docker
+npx prisma migrate deploy
+npm run seed
+npm run dev
+
+# Before committing
+npm run lint
+npm run format
+npm run typecheck
+
+# Inspecting state
+npm run db:studio     # Prisma Studio at :5555
+docker compose logs -f postgres
+```
+
+Full table in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## What NOT to do
+
+- **Don't introduce a state-management library.** The app uses React state + SWR for server state and one Context for the active workspace. Adding Redux/Zustand/Jotai violates the surface area expected by forkers.
+- **Don't reach for a new UI library.** Headless UI + Tailwind is the contract until the planned shadcn/ui migration (Phase E of the v2.0 work). Don't introduce Material UI, Chakra, etc.
+- **Don't add ORM helpers outside of `prisma/services/`.** No raw SQL, no Drizzle, no Kysely.
+- **Don't disable `strict` or `noUncheckedIndexedAccess` "temporarily."** They've already caught real null-deref bugs (see B3 commit messages). If a check is genuinely impossible to satisfy, name the bug and use a narrow `as` cast with a comment.
+- **Don't push secrets.** `.env` is gitignored; `.env.sample` is the only file that should contain key names. If you regenerate `NEXTAUTH_SECRET` for an example, paste a placeholder — never a real value.
+- **Don't bypass CI.** No `--no-verify`, no `--force` without a clear reason.
+- **Don't speculatively refactor.** The boilerplate's value is its readable, minimal surface area. Three similar lines beats a premature abstraction.
+
+## Files to read first if you're new
+
+1. This file.
+2. [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — how multi-tenancy and auth fit together.
+3. `prisma/schema.prisma` — the data model is small (8 models).
+4. `src/lib/server/authorization.ts` — the central authorization helpers; everything else depends on these.
+5. `src/middleware.ts` — the multi-tenancy entry point.
+6. `src/pages/api/workspace/[workspaceSlug]/index.ts` — a representative workspace-scoped route.
+7. `CHANGELOG.md` — what changed recently and why.
+
+## Reporting security issues
+
+[`SECURITY.md`](SECURITY.md). Do not open a public GitHub issue for a vulnerability.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,11 +72,26 @@ See [`docs/ENV.md`](docs/ENV.md) for the full list with usage notes and "where t
 
 ## Project conventions
 
+The short list — the **rules we won't merge a PR that violates**:
+
 - **Authorization on workspace-scoped routes.** Every API route that reads or mutates workspace data must verify authorization with `requireWorkspaceOwner`, `requireWorkspaceMember`, or `requireMemberInOwnedWorkspace` from `src/lib/server/authorization.ts` **before** touching the database. Session presence alone (`validateSession`) is not sufficient — see the v1.4.2 security release notes in `CHANGELOG.md`.
-- **Error response shape.** Use `{ errors: { error: { msg: '...' } } }` so existing client-side toast handling continues to work.
+- **Error response shape.** Use `{ errors: { <field>: { msg: '...' } } }` so existing client-side toast handling continues to work.
 - **Server-only code.** Lives under `src/lib/server/`. Anything imported from there must never end up in a client bundle. Treat the boundary like a hard constraint.
 - **Prisma services.** Live under `prisma/services/`. They are the single layer that talks to the database — routes and pages should never import `@prisma/client` directly.
 - **TypeScript.** `strict: true` and `noUncheckedIndexedAccess: true`. No `any`, no `@ts-ignore` without a comment explaining why.
+
+The full list with rationale and examples lives in [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md).
+
+## Architecture and recipes
+
+If this is your first PR, read these in order:
+
+1. [`CLAUDE.md`](CLAUDE.md) — the operating guide for AI assistants and humans. The fastest way to get oriented.
+2. [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — multi-tenancy, auth, billing, the data model.
+3. [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md) — the rules above plus the rest.
+4. [`docs/RECIPES.md`](docs/RECIPES.md) — copy-paste guides for "add an API route", "add a page", "add a Prisma model", etc.
+
+For AI assistants: this repo also ships [`AGENTS.md`](AGENTS.md) (vendor-neutral pointer) and [`.cursorrules`](.cursorrules) (condensed for Cursor).
 
 ## Submitting a pull request
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,203 @@
+# Architecture
+
+This document explains the moving parts of a Nextacular deployment: how a single Next.js app serves multiple tenants, how authentication maps to workspaces, how custom domains are wired in, and how billing flows from a Stripe webhook back into the session.
+
+Companion docs: [`CONVENTIONS.md`](CONVENTIONS.md) (what every PR should follow), [`RECIPES.md`](RECIPES.md) (how to add common things), [`ENV.md`](ENV.md) (every environment variable).
+
+## Multi-tenancy
+
+A single deployment serves three classes of request:
+
+1. **Marketing and dashboard** at the configured `APP_URL` (e.g. `app.com`, `localhost:3000`).
+2. **Tenant subdomain** at `<workspace-slug>.app.com`.
+3. **Tenant custom domain** at `customer.com`, attached to a workspace via the Vercel Domains API.
+
+All three are the same Next.js process. The mux happens in `src/middleware.ts`:
+
+```ts
+// pseudo-code of the actual middleware
+if (pathname.startsWith('/_sites')) return 404;
+if (hostname === host) return passThrough; // marketing + dashboard
+return rewrite(`/_sites/${hostname}${pathname}`); // tenant
+```
+
+The `/_sites/[site]` Next page (`src/pages/_sites/[site]/index.tsx`) receives `params.site` as either the workspace's `slug` or its custom domain. `getStaticProps` resolves it via `getSiteWorkspace(slug, isCustomDomain)` — the workspace lookup matches either by `slug` directly or by a row in the `Domain` table.
+
+### Setting up a custom domain
+
+1. The workspace owner adds `customer.com` from `account/<slug>/settings/domain`.
+2. The API route `POST /api/workspace/[slug]/domain` calls the Vercel Domains API (`/v9/projects/<id>/domains`) with the workspace's Vercel project credentials and inserts a `Domain` row with the verification token Vercel returns.
+3. The owner adds the TXT / CNAME / A record to their DNS provider using the values shown on the Domain card.
+4. `PUT /api/workspace/[slug]/domain` runs the Vercel `verify` endpoint when the owner clicks **Refresh**; on success the `Domain.verified` boolean is flipped.
+5. Once verified, a request to `customer.com` is rewritten by Vercel's edge to the same Next.js deployment, hits `src/middleware.ts`, and is forwarded to `/_sites/customer.com` where `getSiteWorkspace` finds the workspace via the Domain join.
+
+### Authorization on workspace-scoped routes
+
+The single most important invariant in the codebase. The helpers in `src/lib/server/authorization.ts`:
+
+| Helper                          | Returns on success      | When to use                                                                 |
+| ------------------------------- | ----------------------- | --------------------------------------------------------------------------- |
+| `requireWorkspaceOwner`         | `{ id, name, … }`       | Mutations that only owners may perform (settings, billing, domain, invites) |
+| `requireWorkspaceMember`        | `{ id, name, … }`       | Reads any member may perform (member list, domain list, dashboard)          |
+| `requireMemberInOwnedWorkspace` | `{ member, workspace }` | Mutations targeting a specific `memberId` (role change, remove)             |
+
+All three:
+
+- Take `(req, res, session, slug | memberId)`
+- Verify that `session.user` is the owner / a member / the owner of the workspace owning the target member.
+- Return `null` on denial AND emit the response (`403 Unauthorized`).
+- Are the only correct way to gate workspace data. `validateSession` only confirms there is **a** session, not that the session belongs to the right tenant.
+
+This pattern was added in v1.4.2 as a security fix for an authorization bypass that affected team and domain routes (`CHANGELOG.md`).
+
+## Authentication
+
+NextAuth 4 with the Prisma adapter and a single `EmailProvider` (magic link). All auth surface lives in:
+
+- `src/lib/server/auth.ts` — `authOptions`
+- `src/pages/api/auth/[...nextauth].ts` — the dynamic route
+- `src/lib/server/session-check.ts` — middleware that gates protected routes
+- `src/config/api-validation/session.ts` — the `validateSession` wrapper everything else imports
+
+### Session shape
+
+The session is augmented in two places. `src/types/next-auth.d.ts` declares the shape, and the `callbacks.session` callback in `auth.ts` fills it in on every request:
+
+```ts
+interface Session {
+  user: {
+    userId: string; // copied from user.id; non-standard NextAuth field
+    email: string;
+    name?: string | null;
+    image?: string | null;
+    subscription?: SubscriptionType; // FREE / STANDARD / PREMIUM
+  };
+}
+```
+
+`subscription` is hydrated from the `CustomerPayment` table on every session read. If a route gates a feature on plan tier, it should read `session.user.subscription` (after checking the session exists).
+
+### Sign-in flow
+
+1. User enters their email on `/auth/login`.
+2. `signIn('email', { email })` from `next-auth/react` posts to `/api/auth/signin/email`.
+3. NextAuth's `EmailProvider.sendVerificationRequest` calls `sendMail` (`src/lib/server/mail.ts`), which sends the templated `signin` email through nodemailer.
+4. The user clicks the link in the email (in local dev: in Mailpit at <http://localhost:8025>).
+5. The link verifies the token, NextAuth's `events.signIn` callback runs:
+   - If this is a new user OR has no `CustomerPayment` row yet, `createPaymentAccount(email, user.id)` creates a Stripe Customer and a `CustomerPayment` row. (No subscription is charged here.)
+6. NextAuth issues a JWT session.
+
+The `events.signIn` step is why the magic link works end-to-end even in fresh installs — a fresh sign-up automatically gets a `CustomerPayment` row and is enrolled at `FREE`.
+
+## Workspaces, members, and teams
+
+```
+User ──creates──> Workspace ──has many──> Member ──linked to──> User
+                              ──has many──> Domain
+                              ──owns one──> creator (User)
+```
+
+A `Member` row connects a `User` to a `Workspace` and carries the `teamRole` (OWNER / MEMBER) and `status` (PENDING / ACCEPTED / DECLINED). The user that **creates** a workspace gets a Member row with `teamRole = OWNER` and `status = ACCEPTED` written in the same transaction.
+
+`@@unique([workspaceId, email])` on `Member` means a single email cannot have two rows in the same workspace. The seed script and `joinWorkspace` use the composite key `workspaceId_email` for upserts.
+
+### Joining a workspace
+
+Three paths:
+
+1. **Owner invites by email** at `account/<slug>/settings/team` → `POST /api/workspace/[slug]/invite` → `inviteUsers()` creates `User` rows (`skipDuplicates: true`) and `Member` rows in PENDING state, and sends invitation emails.
+2. **Invitee clicks the invitation email** → lands on `/teams/invite?code=<inviteCode>` → server resolves the code → if signed in, the **Join Workspace** button hits `POST /api/workspace/team/join` → `joinWorkspace(workspaceCode, email)` upserts the Member to ACCEPTED.
+3. **Invitee accepts from their pending-invitations dashboard** at `/account` → `PUT /api/workspace/team/accept` or `/decline` → `updateStatus(memberId, ACCEPTED | DECLINED)`.
+
+## Billing
+
+Stripe Checkout for subscription purchase, Stripe webhooks for state sync.
+
+### Subscribe
+
+1. User clicks **Upgrade** on `/account/billing` → modal lists Stripe products.
+2. Button click → `POST /api/payments/subscription/[priceId]` creates a Stripe Checkout session and returns its `sessionId`.
+3. Client calls `redirectToCheckout(sessionId)` from `@/lib/client/stripe`.
+4. After payment, Stripe redirects to `${APP_URL}/account/payment?status=success` (or `cancelled`).
+
+### Webhook
+
+`POST /api/payments/hooks` receives Stripe events. The raw body is read with `readRawBody` from `@/lib/server/raw-body` (replaces the deprecated `micro` package), then signature-verified against `PAYMENTS_SIGNING_SECRET`.
+
+Currently handled: `charge.succeeded`. The event's `metadata.customerId` and `metadata.type` (a `SubscriptionType`) are passed to `updateSubscription`, which writes back to `CustomerPayment.subscriptionType`. That field is then surfaced via the NextAuth session on the next request.
+
+To handle additional events (e.g. `customer.subscription.deleted` to downgrade), add a case to the switch and a corresponding service function.
+
+### Plan rules
+
+`src/config/subscription-rules/index.ts` declares per-plan quotas:
+
+| Plan     | customDomains | members | workspaces |
+| -------- | ------------- | ------- | ---------- |
+| FREE     | 1             | 1       | 1          |
+| STANDARD | 3             | 5       | 5          |
+| PREMIUM  | 5             | 10      | 10         |
+
+These aren't enforced anywhere yet — they're a contract for forkers to wire up where it matters in their product. See [`RECIPES.md` → "Add a billing-gated feature"](RECIPES.md#add-a-billing-gated-feature).
+
+## Data model
+
+The schema is small. From `prisma/schema.prisma`:
+
+```
+User ──┬── Account[]                        (NextAuth OAuth accounts; unused today)
+       ├── Session[]                        (NextAuth sessions)
+       ├── membership: Member[]             (workspaces this user belongs to, by email)
+       ├── invitedMembers: Member[]         (members this user has invited)
+       ├── createdWorkspace: Workspace[]    (workspaces this user created)
+       ├── customerPayment: CustomerPayment? (1:1 — Stripe-backed billing)
+       └── domains: Domain[]                (workspace domains this user added)
+
+Workspace ──┬── creator: User
+            ├── members: Member[]
+            └── domains: Domain[]
+
+Member (User × Workspace × email)
+  status: InvitationStatus  (PENDING / ACCEPTED / DECLINED)
+  teamRole: TeamRole        (MEMBER / OWNER)
+  @@unique([workspaceId, email])
+
+CustomerPayment (1:1 with User)
+  paymentId       (Stripe Customer id)
+  customerId      (mirrors User.id; the Stripe metadata field)
+  subscriptionType: SubscriptionType  (FREE / STANDARD / PREMIUM)
+
+VerificationToken     (NextAuth magic-link tokens)
+Account / Session     (NextAuth standard tables)
+```
+
+### Soft delete
+
+Most tables have a nullable `deletedAt`. Services consistently filter `where: { deletedAt: null }` and write `data: { deletedAt: new Date() }` rather than calling `.delete()`. There is no global middleware enforcing this — it's a convention you have to remember when adding new queries. If you add a new model that should support soft delete, mirror the existing pattern.
+
+### Indexes
+
+The schema is currently underindexed for queries by `slug`, `email`, and `workspaceId`. PostgreSQL handles the unique constraints automatically (which doubles as an index for those exact lookups), but composite `findFirst` queries on `(deletedAt, slug)` and `(workspaceId, email)` would benefit from explicit `@@index` directives at scale. Worth adding when traffic justifies it.
+
+## App boot order
+
+What happens when a request comes in on `app.com/account`:
+
+1. Vercel (or `next start`) receives the request.
+2. `src/middleware.ts` runs. Hostname matches `APP_URL.host`, so it returns `NextResponse.next()`.
+3. Next.js matches `/account` to `src/pages/account/index.tsx`.
+4. `_app.tsx` initialises NextAuth's `SessionProvider`, SWR config, theme, the workspace context, and i18n.
+5. `AccountLayout` checks `useSession()`:
+   - `loading` → render nothing
+   - `unauthenticated` → `router.replace('/auth/login')`
+   - `authenticated` → render Sidebar + Header + page content
+6. The page itself fetches data via SWR hooks; their fetcher hits `/api/...` routes which call `validateSession` → service → Prisma.
+
+## Things this architecture does NOT do (yet)
+
+- Rate limiting on public or authenticated endpoints. Adding a request-fingerprinting middleware is the recommended pattern.
+- Workspace-scoped feature flags. The closest thing is plan tier, which is global per user.
+- Audit logging. Soft-delete history is preserved but not surfaced.
+- Background jobs. There is no job queue — long-running work (sending bulk invites, processing webhooks) runs inline in the request.
+
+These are intentional omissions for boilerplate scope. Forkers tend to want to choose their own answers (Inngest vs Trigger.dev, Upstash vs Redis, etc.). The architecture above leaves enough seams that any of these can be added without restructuring.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,0 +1,193 @@
+# Conventions
+
+Patterns enforced across this codebase. CI catches the mechanical ones (lint, typecheck, format); the rest live in PR review.
+
+If you're unsure about a non-mechanical rule, find the closest existing file and follow its shape — symmetry across the codebase is a feature.
+
+## TypeScript
+
+- `strict: true` and `noUncheckedIndexedAccess: true` are non-negotiable.
+- No `any` in source files. If a library returns `unknown`, narrow with a type predicate or a Zod schema; don't pass it through.
+- No `@ts-ignore` without a same-line comment that names the underlying bug or upstream issue. Prefer `@ts-expect-error` so the suppression becomes a CI failure once the upstream is fixed.
+- Imports use the `@/...` aliases declared in `tsconfig.json`. Never use deep relative imports (`../../../`).
+- Prefer `import type { … }` for type-only imports; bundlers and `verbatimModuleSyntax` strip them automatically.
+
+## File organization
+
+Every source file has exactly one of the following responsibilities. If a new file doesn't fit, the convention is wrong, not the file — open a PR to extend this list.
+
+| Directory                     | What lives here                                                               | Imports from           |
+| ----------------------------- | ----------------------------------------------------------------------------- | ---------------------- |
+| `prisma/services/`            | Database access functions. Only place that imports `@prisma/client` directly. | server only            |
+| `src/lib/server/`             | Server-only utilities (auth, mail, Stripe, raw body, authorization).          | server only            |
+| `src/lib/common/`             | Code safe to import from either side (e.g. the `apiFetch` helper).            | either                 |
+| `src/lib/client/`             | Browser-only utilities (Clipboard helper, Stripe.js).                         | client only            |
+| `src/config/api-validation/`  | One Zod schema per endpoint, re-exported from `index.ts`.                     | either                 |
+| `src/config/email-templates/` | `html()` + `text()` generators, one file per email.                           | server only            |
+| `src/components/`             | Presentational React components. No data fetching.                            | client                 |
+| `src/sections/`               | Landing-page composition (Hero, Features, Pricing, …).                        | client                 |
+| `src/layouts/`                | Page chrome: `AccountLayout`, `AuthLayout`, `LandingLayout`, `PublicLayout`.  | client                 |
+| `src/hooks/data/`             | One `useSWR` wrapper per resource.                                            | client                 |
+| `src/providers/`              | React Context providers.                                                      | client                 |
+| `src/pages/`                  | Routes (Pages Router).                                                        | either, route by route |
+| `src/types/`                  | Ambient `.d.ts` files (module augmentation only).                             | n/a                    |
+
+The server / client boundary is a hard rule: importing `src/lib/server/*` from anything under `src/components/`, `src/sections/`, or a client-only branch of `src/pages/` will leak server secrets into the bundle. Treat it like a type error.
+
+## API routes
+
+Every API route follows the same skeleton. The canonical example is `src/pages/api/workspace/[workspaceSlug]/name.ts`:
+
+```ts
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import {
+  updateWorkspaceNameSchema,
+  validateSession,
+} from '@/config/api-validation';
+import { requireWorkspaceOwner } from '@/lib/server/authorization';
+import { parseBody } from '@/lib/server/validate';
+import { updateName } from '@/prisma/services/workspace';
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  const { method } = req;
+
+  if (method === 'PUT') {
+    const session = await validateSession(req, res);
+    const body = parseBody(updateWorkspaceNameSchema, req.body, res);
+    if (!body) return;
+    const { workspaceSlug } = req.query as { workspaceSlug: string };
+    const workspace = await requireWorkspaceOwner(
+      req,
+      res,
+      session,
+      workspaceSlug
+    );
+    if (!workspace) return;
+    updateName(
+      session.user.userId,
+      session.user.email,
+      body.name,
+      workspaceSlug
+    )
+      .then((name) => res.status(200).json({ data: { name } }))
+      .catch((error: Error) =>
+        res.status(404).json({ errors: { error: { msg: error.message } } })
+      );
+  } else {
+    res
+      .status(405)
+      .json({ errors: { error: { msg: `${method} method unsupported` } } });
+  }
+};
+
+export default handler;
+```
+
+Notes:
+
+- The method switch is a single `if / else if / else` chain. We don't use a framework like next-connect.
+- `validateSession` ALWAYS comes first.
+- `parseBody` comes next on routes that take a request body.
+- The authorization helper comes next on routes that touch workspace data.
+- Services return the new state; the route serialises it to `{ data: … }`.
+- Errors that originate in services (`throw new Error('Unable to find workspace')`) are caught with `404 + { errors: { error: { msg } } }`. Don't change that shape — the client toaster reads it.
+
+## Error response shape
+
+Both validation failures and business errors use the same envelope:
+
+```json
+{ "errors": { "<field>": { "msg": "<message>" } } }
+```
+
+- For Zod failures, the `<field>` is the dotted path (`members.0.email`).
+- For business errors, the `<field>` is just `error`.
+- For 405s, the `<field>` is `error` and the message is `"<METHOD> method unsupported"`.
+
+The client side reads it with `Object.keys(response.errors).forEach((k) => toast.error(response.errors[k].msg))` — keep the toaster compatibility in mind when adding new error paths.
+
+## Validation
+
+- Server: Zod schemas in `src/config/api-validation/`, parsed via `parseBody`.
+- Client: `validator/lib/...` for instant pre-submit feedback (matches one-shot DOM events).
+- Pages must NOT trust client validation as the source of truth. Zod parsing on the server is the contract.
+
+When you add a new endpoint that takes a body, you almost always need to add a new file under `src/config/api-validation/` and re-export the schema from `index.ts`. Keep one schema per file — when a route changes shape, the diff lives in one place.
+
+## Authorization
+
+See [`ARCHITECTURE.md` → "Authorization on workspace-scoped routes"](ARCHITECTURE.md#authorization-on-workspace-scoped-routes) for the rule. To summarise:
+
+- Authenticated-only reads: `validateSession` alone is fine (e.g. `/api/workspaces` returns the current user's workspaces).
+- Workspace-scoped reads (members, domains, settings): `requireWorkspaceMember`.
+- Workspace-scoped writes (rename, invite, delete, change domain): `requireWorkspaceOwner`.
+- Operations targeting a specific `memberId` without the workspace slug in the URL: `requireMemberInOwnedWorkspace`.
+
+If you can't decide between Owner and Member, default to **Owner** and loosen later. Tightening is harder than loosening.
+
+## Pages
+
+- Files under `src/pages/account/**` use `AccountLayout`. Inside that layout, `useSession` handles the unauthenticated redirect.
+- Files under `src/pages/auth/**` use `AuthLayout`.
+- Landing and payment-status pages use `LandingLayout` / `PublicLayout`.
+- Subdomain / custom-domain tenant content lives in `src/pages/_sites/[site]/`. The middleware rewrites those requests automatically; you never link to `/_sites/...` from a page.
+
+### `getServerSideProps`
+
+- Always type the return: `GetServerSideProps<MyProps>`.
+- Get the session with `getSession(context)` from `next-auth/react`.
+- If the data fetch requires a session and there is none, return `{ redirect: { destination: '/auth/login', permanent: false } }` rather than letting downstream code crash.
+- Narrow `context.params?.foo` from `string | string[] | undefined` before passing it to a service — Prisma queries with `undefined` segments throw.
+
+## React components
+
+- Functional components with destructured-default props. No `defaultProps` (deprecated on function components in React 18.3+).
+- Compound components (e.g. `Card`, `Content`) use `React.FC` for sub-components with named `displayName` assignments — see `src/components/Card/index.tsx` for the canonical pattern. This both typechecks cleanly and gives readable names in React DevTools.
+- Event handler types: `ChangeEvent<HTMLInputElement>`, `MouseEvent<HTMLButtonElement>`, `KeyboardEvent<...>`. Don't use the bare `React.SyntheticEvent`.
+- `children` is typed as `ReactNode` (or `ReactNode | undefined` if optional).
+
+## SWR
+
+- One hook per resource, in `src/hooks/data/`.
+- Pattern: `(slug) => useSWR<{ data?: { … } }>(apiRoute)`; return `{ data, isLoading: !error && !data, isError: error }`.
+- The fetcher and `onError` come from `src/config/swr/index.ts` and are wired in `_app.tsx`. Don't pass a custom `fetcher` to individual hooks.
+- After a mutation, invalidate with `mutate(apiRoute)` from `'swr'`. The settings/domain page is the only example today.
+
+## i18n
+
+- All user-facing strings go through `useTranslation()`.
+- Keys live in `src/messages/en.json`. Use dot notation (`settings.workspace.delete`).
+- We only ship English today. When adding a new locale, mirror the file structure.
+- Don't interpolate untrusted strings into translation values — use placeholders.
+
+## Naming
+
+| Kind                | Convention           | Example                          |
+| ------------------- | -------------------- | -------------------------------- |
+| Files               | kebab-case           | `api-validation/update-email.ts` |
+| Component files     | PascalCase           | `components/Card/index.tsx`      |
+| Type names          | PascalCase           | `WorkspaceForDomain`             |
+| Zod schemas         | camelCase + `Schema` | `updateWorkspaceNameSchema`      |
+| Inferred body types | PascalCase + `Body`  | `UpdateWorkspaceNameBody`        |
+| Service functions   | camelCase verbs      | `inviteUsers`, `getOwnWorkspace` |
+| API response data   | `{ data: { … } }`    | `res.json({ data: { name } })`   |
+| API errors          | `{ errors: { … } }`  | see "Error response shape"       |
+| Hooks               | `useThing`           | `useWorkspaces`, `useMembers`    |
+| Boolean props       | `is…` / `has…`       | `isLoading`, `isTeamOwner`       |
+
+## Commits and PRs
+
+- Commit messages: imperative, scope-prefixed (`fix(security): ...`, `chore(b5b): ...`, `feat: ...`). The body describes **why** the change is needed; the **what** is in the diff.
+- One logical change per PR. If your PR description has to use the word "and" three times, split it.
+- For user-facing changes, add a note to `CHANGELOG.md` under `[Unreleased]`.
+- Never bypass CI hooks. If a hook fails, fix the underlying issue.
+
+## What we don't do
+
+- We don't use class components.
+- We don't use Redux / Zustand / Jotai. React state + SWR + one Context (`WorkspaceProvider`) is enough.
+- We don't add helper libraries for things that are one-liners (e.g. lodash, ramda).
+- We don't expose server secrets behind `NEXT_PUBLIC_*`. Anything with that prefix is bundled into the client JavaScript.
+- We don't use `console.log` outside the dev-mode mail fallback. ESLint warns on it.
+- We don't write `// TODO` comments without an issue number. If it's worth tracking, file it.

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -1,0 +1,326 @@
+# Recipes
+
+Step-by-step guides for common tasks. Each recipe is a copy-paste-friendly skeleton — adapt the names, then the rest of the structure should work as-is.
+
+If you're new to the codebase, read [`ARCHITECTURE.md`](ARCHITECTURE.md) and [`CONVENTIONS.md`](CONVENTIONS.md) first.
+
+## Add an API route
+
+For a route that doesn't touch workspace data (e.g. an authenticated-user lookup):
+
+1. **Create the file** under `src/pages/api/...`. Pages Router uses the file path as the URL.
+2. **Pick a method** and add the skeleton:
+
+   ```ts
+   // src/pages/api/widgets/index.ts
+   import type { NextApiRequest, NextApiResponse } from 'next';
+   import { validateSession } from '@/config/api-validation';
+   import { getWidgets } from '@/prisma/services/widget';
+
+   const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+     const { method } = req;
+
+     if (method === 'GET') {
+       const session = await validateSession(req, res);
+       const widgets = await getWidgets(session.user.userId);
+       res.status(200).json({ data: { widgets } });
+     } else {
+       res
+         .status(405)
+         .json({ errors: { error: { msg: `${method} method unsupported` } } });
+     }
+   };
+
+   export default handler;
+   ```
+
+3. **If the route takes a body**, add a Zod schema and use `parseBody`:
+   - Create `src/config/api-validation/create-widget.ts` exporting `createWidgetSchema` and the inferred `CreateWidgetBody` type.
+   - Re-export from `src/config/api-validation/index.ts`.
+   - In the handler: `const body = parseBody(createWidgetSchema, req.body, res); if (!body) return;`.
+
+4. **If the route touches workspace data**, see the next recipe.
+
+## Add a workspace-scoped API route
+
+This is the security-critical case. Follow the skeleton exactly:
+
+```ts
+// src/pages/api/workspace/[workspaceSlug]/widgets.ts
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { createWidgetSchema, validateSession } from '@/config/api-validation';
+import { requireWorkspaceOwner } from '@/lib/server/authorization';
+import { parseBody } from '@/lib/server/validate';
+import { createWidget } from '@/prisma/services/widget';
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  const { method } = req;
+
+  if (method === 'POST') {
+    const session = await validateSession(req, res);
+    const body = parseBody(createWidgetSchema, req.body, res);
+    if (!body) return;
+
+    const { workspaceSlug } = req.query as { workspaceSlug: string };
+    const workspace = await requireWorkspaceOwner(
+      req,
+      res,
+      session,
+      workspaceSlug
+    );
+    if (!workspace) return;
+
+    await createWidget(workspace.id, body.name);
+    res.status(200).json({ data: { name: body.name } });
+  } else {
+    res
+      .status(405)
+      .json({ errors: { error: { msg: `${method} method unsupported` } } });
+  }
+};
+
+export default handler;
+```
+
+Order matters: `validateSession` → `parseBody` → `requireWorkspaceOwner|Member`. The authorization check MUST be before any service call that hits the database. Use `requireWorkspaceMember` instead of `requireWorkspaceOwner` for read endpoints any member should see. Use `requireMemberInOwnedWorkspace` when the route operates on a `memberId` instead of a `workspaceSlug` (see `src/pages/api/workspace/team/role.ts`).
+
+## Add a page
+
+Pages are matched by their file path. Pick the right directory based on layout:
+
+| Directory                             | Layout          | Auth                                 |
+| ------------------------------------- | --------------- | ------------------------------------ |
+| `src/pages/index.tsx`                 | `LandingLayout` | optional                             |
+| `src/pages/auth/*`                    | `AuthLayout`    | redirects to `/account` if signed in |
+| `src/pages/account/*`                 | `AccountLayout` | redirects to `/auth/login` if not    |
+| `src/pages/account/[workspaceSlug]/*` | `AccountLayout` | + active workspace required          |
+| `src/pages/_sites/[site]/*`           | (custom)        | none — tenant marketing              |
+
+For a workspace-scoped page with server-side props:
+
+```tsx
+// src/pages/account/[workspaceSlug]/widgets.tsx
+import type { GetServerSideProps } from 'next';
+import { getSession } from 'next-auth/react';
+
+import Content from '@/components/Content/index';
+import Meta from '@/components/Meta/index';
+import { AccountLayout } from '@/layouts/index';
+import { getWorkspace, isWorkspaceOwner } from '@/prisma/services/workspace';
+import type { Workspace } from '@/providers/workspace';
+
+type WidgetsProps = {
+  isTeamOwner: boolean;
+  workspace: Workspace | null;
+};
+
+const Widgets = ({ isTeamOwner, workspace }: WidgetsProps) => {
+  if (!workspace) return null;
+  return (
+    <AccountLayout>
+      <Meta title={`Nextacular - ${workspace.name} | Widgets`} />
+      <Content.Title title="Widgets" subtitle="Manage your widgets" />
+      <Content.Divider />
+      {/* … */}
+    </AccountLayout>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps<WidgetsProps> = async (
+  context
+) => {
+  const session = await getSession(context);
+  if (!session?.user) {
+    return { redirect: { destination: '/auth/login', permanent: false } };
+  }
+
+  const workspaceSlug =
+    typeof context.params?.workspaceSlug === 'string'
+      ? context.params.workspaceSlug
+      : '';
+  const dbWorkspace = workspaceSlug
+    ? await getWorkspace(session.user.userId, session.user.email, workspaceSlug)
+    : null;
+
+  return {
+    props: {
+      isTeamOwner: dbWorkspace
+        ? isWorkspaceOwner(session.user.email, dbWorkspace)
+        : false,
+      workspace: dbWorkspace
+        ? { ...(dbWorkspace as Workspace), slug: workspaceSlug }
+        : null,
+    },
+  };
+};
+
+export default Widgets;
+```
+
+The handler-level redirect on missing session is important — without it, a `getServerSideProps` for an authenticated page will throw on `session.user.userId` instead of bouncing to login.
+
+## Add a data hook
+
+Thin wrapper around `useSWR`. Pattern (`src/hooks/data/useMembers.ts`):
+
+```ts
+import useSWR from 'swr';
+
+type Widget = { id: string; name: string };
+
+type UseWidgetsResult = {
+  data?: { widgets: Widget[] };
+  isLoading: boolean;
+  isError: unknown;
+};
+
+const useWidgets = (slug: string): UseWidgetsResult => {
+  const apiRoute = `/api/workspace/${slug}/widgets`;
+  const { data, error } = useSWR<{ data?: { widgets: Widget[] } }>(apiRoute);
+  return {
+    ...data,
+    isLoading: !error && !data,
+    isError: error,
+  };
+};
+
+export default useWidgets;
+```
+
+Then re-export from `src/hooks/data/index.ts`.
+
+Callers consume it as `const { data, isLoading } = useWidgets(workspace.slug);` and read `data?.widgets`.
+
+For mutations: don't put the POST/PUT inside the hook. Call `apiFetch` from the component, then `mutate(apiRoute)` to revalidate.
+
+## Add a Prisma model
+
+1. **Edit `prisma/schema.prisma`.** Mirror the existing models:
+   - cuid IDs (`@id @default(cuid())`).
+   - Optional `createdAt`, `deletedAt`, `updatedAt` fields if soft delete is in scope.
+   - Snake_case table name via `@@map`.
+   - Compound unique constraints with `@@unique` where appropriate.
+2. **Generate the migration.** With the docker compose stack running:
+
+   ```sh
+   npx prisma migrate dev --name add_widget_model
+   ```
+
+3. **Add a service** at `prisma/services/widget.ts`. Service functions are the only place that imports from `@prisma/client`. Follow `prisma/services/membership.ts` for the read/write pattern:
+
+   ```ts
+   import { type Widget } from '@prisma/client';
+   import prisma from '@/prisma/index';
+
+   export const getWidgets = async (workspaceId: string): Promise<Widget[]> =>
+     prisma.widget.findMany({
+       where: { workspaceId, deletedAt: null },
+       orderBy: { createdAt: 'desc' },
+     });
+
+   export const createWidget = async (
+     workspaceId: string,
+     name: string
+   ): Promise<Widget> => prisma.widget.create({ data: { workspaceId, name } });
+
+   export const softDeleteWidget = async (id: string): Promise<void> => {
+     await prisma.widget.update({
+       where: { id },
+       data: { deletedAt: new Date() },
+     });
+   };
+   ```
+
+4. **Update the seed** if the demo workspace should include some of the new model. Edit `prisma/seed.ts` and run `npm run seed`.
+
+## Add a billing-gated feature
+
+Plan tiers are read from the session:
+
+```ts
+const session = await validateSession(req, res);
+if (session.user.subscription === 'FREE') {
+  return res.status(402).json({
+    errors: {
+      plan: { msg: 'Upgrade to STANDARD or PREMIUM to use this feature' },
+    },
+  });
+}
+```
+
+For quota-style limits (e.g. "FREE workspaces can have at most 1 custom domain"):
+
+```ts
+import rules from '@/config/subscription-rules';
+
+const plan = session.user.subscription ?? 'FREE';
+const limit = rules[plan].customDomains;
+const current = await prisma.domain.count({
+  where: { workspaceId: workspace.id, deletedAt: null },
+});
+if (current >= limit) {
+  return res.status(402).json({
+    errors: {
+      plan: {
+        msg: `Plan limit reached (${limit}). Upgrade to add more domains.`,
+      },
+    },
+  });
+}
+```
+
+`subscription-rules` is a `Record<SubscriptionType, { customDomains, members, workspaces }>` — add fields as your product needs them.
+
+On the client, gate UI on `useSession().data?.user.subscription` (same field, hydrated from the session callback in `src/lib/server/auth.ts`).
+
+## Add a landing section
+
+Landing-page composition lives in `src/sections/`. Each section is a self-contained, prop-less React component that exports default:
+
+```tsx
+// src/sections/Trust.tsx
+const Trust = () => (
+  <section className="w-full py-10 bg-gray-50">{/* … */}</section>
+);
+export default Trust;
+```
+
+Re-export from `src/sections/index.ts`, then compose into the landing page in `src/pages/index.tsx`. Order in the file is the visual order.
+
+## Add an environment variable
+
+1. **Decide where it's used.** Server-only stays unprefixed; values the browser needs must use `NEXT_PUBLIC_*` (and only public values).
+2. **Read it through `process.env.NAME`.** Always guard against missing values in code that may run without the variable set (Stripe / Vercel / GA features are all optional today).
+3. **Add it to `.env.sample`** with a one-line comment explaining what it is and a sensible default for the docker-compose stack.
+4. **Document it in [`docs/ENV.md`](ENV.md)** — add a row to the quick-reference table and a section with the where-to-get-it instructions.
+
+## Add a translation key
+
+1. Add the key to `src/messages/en.json`. Use dot-notation paths.
+2. Use it via `useTranslation()`:
+
+   ```tsx
+   const { t } = useTranslation();
+   return <h1>{t('widgets.header.title')}</h1>;
+   ```
+
+3. Don't hard-code English strings in JSX — even for boilerplate copy, the key system makes downstream localisation trivial.
+
+## Send an email
+
+Use `sendMail` from `src/lib/server/mail.ts` with one of the existing templates in `src/config/email-templates/` (or add a new template alongside the others). In local dev all email is captured by Mailpit at <http://localhost:8025>.
+
+```ts
+import { html, text } from '@/config/email-templates/invitation';
+import { sendMail } from '@/lib/server/mail';
+
+await sendMail({
+  to: recipient,
+  subject: `[Nextacular] You have been invited to join ${workspace.name}`,
+  html: html({ code: workspace.inviteCode, name: workspace.name }),
+  text: text({ code: workspace.inviteCode, name: workspace.name }),
+});
+```
+
+Each template is a pair of `html({...}) -> string` / `text({...}) -> string` functions with the same input type. Mirror that shape when adding new templates.


### PR DESCRIPTION
…ECIPES.md

Adds the AI-assist and contributor documentation layer. After this PR, a new contributor — human or AI — can go from `git clone` to a correctly-shaped first PR without having to read every file in src/.

Repo-root files:

- CLAUDE.md (canonical) — operating guide for Claude Code, Cursor, Copilot, and any AI assistant. Covers what the project is, the versioned tech stack, the full src/ + prisma/ + docs/ file map, the one-paragraph architecture, the nine "won't merge if you violate this" conventions, where to look when adding common things, shell commands, and an explicit "don't do this" list (no state-mgmt library, no raw SQL, no Headless UI 2 / shadcn until Phase E, etc.). Also lists the six files to read first if you're new.
- AGENTS.md — short, vendor-neutral pointer to CLAUDE.md so agents that look for AGENTS.md first (Codex CLI, generic LLM tools) find their way.
- .cursorrules — condensed ~30-line subset for Cursor IDE: the eight hard rules and the four canonical pattern files.

docs/ deep dives:

- ARCHITECTURE.md — multi-tenancy (subdomain + custom domain routing via middleware → /_sites/[site]), authentication (NextAuth magic link, session shape, the events.signIn → CustomerPayment bootstrap), workspaces / members / teams (3 join paths), billing (Checkout + webhook → updateSubscription → session), the data model (8 models with an ASCII relationship sketch), and a "what this architecture doesn't do yet" section so forkers know where the seams are (rate limiting, feature flags, audit logs, background jobs).
- CONVENTIONS.md — the long form of the CLAUDE.md "rules" section: TypeScript, file organization with a directory→responsibility table, the canonical API route skeleton, the error envelope, the Zod validation pattern, the authorization-helper decision tree, page conventions including getServerSideProps, React component patterns (FC + named displayName, no defaultProps), SWR pattern, i18n, naming, commit style, and a "things we don't do" list.
- RECIPES.md — copy-paste guides: "Add an API route", "Add a workspace-scoped API route" (with the full security-critical skeleton), "Add a page" (with the layout-by-directory table), "Add a data hook", "Add a Prisma model", "Add a billing-gated feature" (using the subscription-rules tier table), "Add a landing section", "Add an environment variable", "Add a translation key", and "Send an email".

CONTRIBUTING.md updated to point at the new docs from the "Project conventions" and "Architecture and recipes" sections. CHANGELOG Unreleased now lists every doc added and every B5 dependency change made in the sibling PRs.

Verified locally: lint, typecheck, format:check all clean. No source file changes in this PR.

<!--
Thanks for contributing to Nextacular! Before opening a PR please:

1. Read CONTRIBUTING.md.
2. Run `npm run lint` and `npm run format` locally.
3. If you're adding a workspace-scoped API route, use the
   `requireWorkspaceOwner` / `requireWorkspaceMember` helpers in
   `src/lib/server/authorization.js`.
4. If this PR contains a security fix, please coordinate with the
   maintainers per SECURITY.md before opening it publicly.
-->

## Summary

<!-- One or two sentences on what this PR does and why. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Tooling / CI / DX
- [ ] Refactor / code cleanup

## Test plan

<!-- Checklist of what you tested and how. Include screenshots if UI changed. -->

- [ ]
- [ ]

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run format:check` passes
- [ ] `npm run build` succeeds locally
- [ ] CHANGELOG.md updated (for user-facing changes)
- [ ] Docs updated (README, CLAUDE.md, docs/\*) where relevant
- [ ] No new env vars added without `.env.sample` entry and documentation

## Related issues

<!-- Closes #123, refs #456 -->
