### PR TITLE
fix(mail): honour EMAIL_SERVER_HOST/PORT so any SMTP provider can be configured

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -28,8 +28,14 @@ DATABASE_URL=postgresql://nextacular:nextacular@localhost:5432/nextacular
 EMAIL_FROM=Nextacular <hello@nextacular.test>
 EMAIL_SERVER_USER=
 EMAIL_SERVER_PASSWORD=
-# Use any well-known nodemailer service (https://nodemailer.com/smtp/well-known/)
-# or leave blank to use the SMTP host/port defaults.
+# Point at an SMTP server directly. Takes precedence over EMAIL_SERVICE.
+# These defaults match the Mailpit container in docker-compose.yml.
+EMAIL_SERVER_HOST=localhost
+EMAIL_SERVER_PORT=1025
+# Implicit TLS. Defaults to true only on port 465; 587/25/1025 use STARTTLS.
+# EMAIL_SERVER_SECURE=false
+# Alternative to EMAIL_SERVER_HOST: any well-known nodemailer service
+# (https://nodemailer.com/smtp/well-known/). Ignored when a host is set.
 EMAIL_SERVICE=
 
 ###

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CLAUDE.md` at repo root — operating guide for Claude Code, Cursor, GitHub Copilot, and any AI assistant. Mirrored by a short `AGENTS.md` pointer and a condensed `.cursorrules` for Cursor IDE.
 - Rewritten `.env.sample` with defaults that match `docker-compose.yml` and inline guidance grouped by feature area.
 - `tsx` devDependency so Prisma can run TypeScript seed and script files directly.
+- `EMAIL_SERVER_HOST`, `EMAIL_SERVER_PORT`, and `EMAIL_SERVER_SECURE` — point the mail transport at a raw SMTP server. Previously only `EMAIL_SERVICE` was read, so providers absent from [nodemailer's well-known list](https://nodemailer.com/smtp/well-known/) (and the local Mailpit container on port 1025) could not be configured at all, despite `.env.sample` and `docs/ENV.md` documenting host/port support. `EMAIL_SERVICE` still works and is unchanged when no host is set.
 - Server-side validation via Zod (`src/lib/server/validate.ts` → `parseBody`); schemas live in `src/config/api-validation/`.
 - `src/lib/client/clipboard.ts` (native Clipboard API wrapper) and `src/lib/server/raw-body.ts` (Stripe webhook raw body reader).
 

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -15,6 +15,9 @@ A variable is **Required** if the app refuses to boot without it, **Conditional*
 | `EMAIL_FROM`                      | Conditional | Magic-link sign-in, invite/notify emails |
 | `EMAIL_SERVER_USER`               | Conditional | SMTP auth (nodemailer)                   |
 | `EMAIL_SERVER_PASSWORD`           | Conditional | SMTP auth (nodemailer)                   |
+| `EMAIL_SERVER_HOST`               | Conditional | SMTP host — overrides `EMAIL_SERVICE`    |
+| `EMAIL_SERVER_PORT`               | Conditional | SMTP port (defaults to nodemailer's)     |
+| `EMAIL_SERVER_SECURE`             | Optional    | Force implicit TLS on/off                |
 | `EMAIL_SERVICE`                   | Conditional | Nodemailer well-known SMTP service       |
 | `NEXT_PUBLIC_PUBLISHABLE_KEY`     | Conditional | Stripe.js on the billing page (client)   |
 | `PAYMENTS_SECRET_KEY`             | Conditional | Stripe SDK (server)                      |
@@ -38,7 +41,8 @@ DATABASE_URL=postgresql://nextacular:nextacular@localhost:5432/nextacular
 EMAIL_FROM="Nextacular <hello@nextacular.test>"
 EMAIL_SERVER_USER=
 EMAIL_SERVER_PASSWORD=
-EMAIL_SERVICE=
+EMAIL_SERVER_HOST=localhost
+EMAIL_SERVER_PORT=1025
 ADMIN_EMAIL=admin@nextacular.test
 ```
 
@@ -75,17 +79,33 @@ Standard PostgreSQL connection string. Examples:
 
 Prisma Migrate creates a temporary "shadow" database to detect unsafe schema changes. Most managed databases don't allow the database owner to `CREATE DATABASE`, so you need to point this at a separate, empty Postgres URL. Not required when running locally against a permissive Postgres.
 
-### Email (`EMAIL_FROM`, `EMAIL_SERVER_USER`, `EMAIL_SERVER_PASSWORD`, `EMAIL_SERVICE`)
+### Email (`EMAIL_FROM`, `EMAIL_SERVER_*`, `EMAIL_SERVICE`)
 
 Required to deliver magic-link sign-in emails (NextAuth's `EmailProvider`) and workspace invitations.
 
 - `EMAIL_FROM`: the sender address. Format: `Name <email@domain>` or plain `email@domain`.
-- `EMAIL_SERVICE`: matches a [nodemailer well-known service](https://nodemailer.com/smtp/well-known/) (e.g. `gmail`, `outlook`, `mailgun`). Leave blank if you supply a raw SMTP host/port via additional env vars.
 - `EMAIL_SERVER_USER` / `EMAIL_SERVER_PASSWORD`: SMTP credentials.
 
-For local development the `docker compose` stack runs [Mailpit](https://mailpit.axllent.org/). All outgoing mail is captured at <http://localhost:8025> and no credentials are required — leave `EMAIL_SERVER_USER` / `EMAIL_SERVER_PASSWORD` empty. Mailpit accepts any SMTP auth.
+Point the transport at a server in one of two ways:
 
-For production: use Resend, SendGrid, Postmark, AWS SES, or any other transactional email provider that exposes SMTP credentials.
+- `EMAIL_SERVER_HOST` / `EMAIL_SERVER_PORT` — a raw SMTP host. Works with every provider, and is the only option for a provider that nodemailer does not ship a shorthand for.
+- `EMAIL_SERVICE` — matches a [nodemailer well-known service](https://nodemailer.com/smtp/well-known/) (e.g. `gmail`, `outlook`, `mailgun`). Only these names resolve; anything else fails to connect.
+
+`EMAIL_SERVER_HOST` takes precedence when both are set.
+
+`EMAIL_SERVER_SECURE` forces implicit TLS on (`true`) or off (`false`). Leave it unset unless you have a reason: it defaults to `true` on port 465 and `false` everywhere else, which is correct for 587, 25, and Mailpit's 1025 (all of which upgrade via STARTTLS).
+
+For local development the `docker compose` stack runs [Mailpit](https://mailpit.axllent.org/) on port 1025. All outgoing mail is captured at <http://localhost:8025> and no credentials are required — leave `EMAIL_SERVER_USER` / `EMAIL_SERVER_PASSWORD` empty. Mailpit accepts any SMTP auth.
+
+For production, use any transactional provider that exposes SMTP credentials:
+
+| Provider | Host                                | Port |
+| -------- | ----------------------------------- | ---- |
+| Resend   | `smtp.resend.com`                   | 587  |
+| SendGrid | `smtp.sendgrid.net`                 | 587  |
+| Postmark | `smtp.postmarkapp.com`              | 587  |
+| AWS SES  | `email-smtp.<region>.amazonaws.com` | 587  |
+| MailKite | `smtp.mailkite.dev`                 | 587  |
 
 ### Stripe billing (`NEXT_PUBLIC_PUBLISHABLE_KEY`, `PAYMENTS_SECRET_KEY`, `PAYMENTS_SIGNING_SECRET`)
 

--- a/src/lib/server/mail.ts
+++ b/src/lib/server/mail.ts
@@ -1,12 +1,35 @@
 import nodemailer from 'nodemailer';
 import type SMTPTransport from 'nodemailer/lib/smtp-transport';
 
+const host = process.env.EMAIL_SERVER_HOST;
+const port = process.env.EMAIL_SERVER_PORT
+  ? Number(process.env.EMAIL_SERVER_PORT)
+  : undefined;
+
+if (port !== undefined && !Number.isInteger(port)) {
+  throw new Error(
+    `EMAIL_SERVER_PORT must be an integer, received "${process.env.EMAIL_SERVER_PORT}"`
+  );
+}
+
+// `secure` means "open the connection with TLS immediately", which is only
+// correct for implicit-TLS ports (465). Everything else — 587, 25, Mailpit's
+// 1025 — starts in plaintext and upgrades via STARTTLS.
+const secure = process.env.EMAIL_SERVER_SECURE
+  ? process.env.EMAIL_SERVER_SECURE === 'true'
+  : port === 465;
+
+/**
+ * A raw `host` wins over `service`. Nodemailer's `service` shorthand only
+ * resolves names from its built-in well-known list, so providers outside that
+ * list (and the local Mailpit container) need an explicit host/port.
+ */
 export const emailConfig: SMTPTransport.Options = {
   auth: {
     user: process.env.EMAIL_SERVER_USER,
     pass: process.env.EMAIL_SERVER_PASSWORD,
   },
-  service: process.env.EMAIL_SERVICE,
+  ...(host ? { host, port, secure } : { service: process.env.EMAIL_SERVICE }),
 };
 
 const transporter = nodemailer.createTransport(emailConfig);


### PR DESCRIPTION
## Summary

`src/lib/server/mail.ts` only ever set nodemailer's `service` shorthand, which resolves names from its [built-in well-known list](https://nodemailer.com/smtp/well-known/). Any provider outside that list cannot be configured at all — there is no way to supply a host.

Both `.env.sample` and `docs/ENV.md` already document the escape hatch:

> `EMAIL_SERVICE`: … Leave blank if you supply a raw SMTP host/port **via additional env vars**.

No such variables were ever read. This PR adds them.

It also affects local dev: the docker-compose Mailpit container listens on **1025**, but with no host/port the transport falls back to nodemailer's default (`localhost:587`). That has gone unnoticed because `sendMail` short-circuits to `console.log` whenever `NODE_ENV !== 'production'`, so the transporter is never exercised outside production.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Tooling / CI / DX
- [ ] Refactor / code cleanup

## What changed

- `EMAIL_SERVER_HOST` / `EMAIL_SERVER_PORT` / `EMAIL_SERVER_SECURE` are now read. A host takes precedence over `service`.
- **Backwards compatible**: with no host set, `emailConfig` is byte-identical to before, so existing `EMAIL_SERVICE` deployments are untouched.
- `secure` defaults to `true` only on port 465 (implicit TLS) and `false` elsewhere — correct for 587, 25 and 1025, which all upgrade via STARTTLS. Overridable when someone has an unusual setup.
- `EMAIL_SERVER_PORT` is validated, so a typo fails loudly at startup rather than silently connecting to a default port.
- `docs/ENV.md` gains a host/port table for common providers; `.env.sample` defaults now actually match the Mailpit container.

## Test plan

No test runner is configured in this repo, so I verified the resolved config directly against the built module across every env combination:

| Env | Resolved config |
| --- | --- |
| `EMAIL_SERVICE=gmail` (no host) | `{"service":"gmail"}` — unchanged |
| nothing set | `{}` — unchanged |
| host + `587` | `{"host":"…","port":587,"secure":false}` |
| host + `1025` (Mailpit) | `{"host":"localhost","port":1025,"secure":false}` |
| host + `465` | `{"host":"…","port":465,"secure":true}` |
| host + `587` + `SECURE=true` | `{"host":"…","port":587,"secure":true}` |
| host + service both set | host wins |
| host, no port | `{"host":"…","secure":false}` |
| `PORT=not-a-number` | throws `EMAIL_SERVER_PORT must be an integer, received "not-a-number"` |

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run typecheck` passes
- [x] `next build` reaches `✓ Compiled successfully`

## Checklist

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [ ] `npm run build` succeeds locally — **not fully verified.** It compiles, but page-data collection needs Postgres (`/_sites/[site]`) and Stripe keys (`/account/billing`), and I have no Docker on this machine. I confirmed the same two failures occur on a pristine `main` checkout with identical env, so they are pre-existing and unrelated. CI has the Postgres service container and should complete the build.
- [x] CHANGELOG.md updated
- [x] Docs updated (`docs/ENV.md`, `.env.sample`)
- [x] No new env vars added without `.env.sample` entry and documentation

## Disclosure

I work on MailKite, which is one of the five providers listed in the new `docs/ENV.md` table. That is how I hit this bug — MailKite isn't in nodemailer's well-known list, so there was no way to configure it.

The fix is deliberately provider-neutral: no dependency, no special-casing, no vendor code path. It's a plain host/port option that benefits Resend, SES, Postmark and any self-hosted relay equally, and the docs row is one line alongside the others. Happy to drop the MailKite row from the table if you'd rather keep the docs to providers you already list — the code change stands on its own either way.

Generated with the help of Claude Code, reviewed by me before opening.
